### PR TITLE
Added Note for Mac Network Issue

### DIFF
--- a/blog/2022-06-24-quickstart-kind/index.md
+++ b/blog/2022-06-24-quickstart-kind/index.md
@@ -100,6 +100,8 @@ _Refer to the value of `fqdn.domain` in your [values.yaml](https://github.com/pa
 
 Open your favorite web browser and navigate to `http://console.paralus.local`, you will be see the dashboard with the login screen
 
+> **Note:** Docker-for-Mac does not expose container networks directly on the macOS host & hence you will not be able to access Paralus dashboard if you're on a Mac machine. We suggest using [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) utility to overcome this issue.
+
 ### Resetting Default Password
 
 Paralus comes configured with default credentials that allow you to access the dashboard.

--- a/blog/2022-07-29-paralus-quickstart-microk8s/index.md
+++ b/blog/2022-07-29-paralus-quickstart-microk8s/index.md
@@ -191,6 +191,8 @@ Edit the `/etc/hosts` file using your favourite editor and add the following lin
 
 Open your favorite web browser and navigate to `http://console.paralus.local`, you will be see the dashboard with the login screen
 
+> **Note:** Docker-for-Mac does not expose container networks directly on the macOS host & hence you will not be able to access Paralus dashboard if you're on a Mac machine. We suggest using [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) utility to overcome this issue.
+
 ### Resetting Default Password
 
 Paralus comes configured with default credentials that allow you to access the dashboard.

--- a/docs/References/troubleshooting.md
+++ b/docs/References/troubleshooting.md
@@ -33,6 +33,12 @@ curl -X POST http://$RELEASE_NAME-kratos-admin/recovery/link \
 -H 'Content-Type: application/json' -d '{"expires_in":"10m","identity_id":"<ADMIN_USER_ID>"}'
 ```
 
+## Accessing Paralus Dashboard on MacOS
+
+If you are using a Mac based machine, you might have issues accessing the Paralus dashboard. The reason is that Docker-for-Mac does not expose container networks directly on the macOS host & hence you cannot access the Paralus dashboard.
+
+Wsuggest using [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) utility to overcome this issue. This utility creates a minimal network tunnel between macOS and the Docker Desktop Linux VM.
+
 ## Cluster Import
 
 If you get errors while importing a cluster into Paralus, it may well be one of the following reasons:

--- a/docs/References/troubleshooting.md
+++ b/docs/References/troubleshooting.md
@@ -37,7 +37,7 @@ curl -X POST http://$RELEASE_NAME-kratos-admin/recovery/link \
 
 If you are using a Mac based machine, you might have issues accessing the Paralus dashboard. The reason is that Docker-for-Mac does not expose container networks directly on the macOS host & hence you cannot access the Paralus dashboard.
 
-Wsuggest using [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) utility to overcome this issue. This utility creates a minimal network tunnel between macOS and the Docker Desktop Linux VM.
+We suggest using [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) utility to overcome this issue. This utility creates a minimal network tunnel between macOS and the Docker Desktop Linux VM.
 
 ## Cluster Import
 


### PR DESCRIPTION
Added a note for Mac users to be able access Paralus dashboard.

Fixes Issue: [cannot access Paralus Dashboard in M1 Mac](https://github.com/paralus/paralus/issues/68)