### PR TITLE
Fix incorrect blog post url

### DIFF
--- a/blog/2023-01-13-paralus-sandbox/index.md
+++ b/blog/2023-01-13-paralus-sandbox/index.md
@@ -1,5 +1,5 @@
 ---
-slug: paralus-cnfc-sandbox-project
+slug: paralus-cncf-sandbox-project
 title: "Paralus Is Now A CNCF Sandbox Project"
 authors: [atul]
 tags: [paralus]


### PR DESCRIPTION
Fixed the blog post url:
`https://www.paralus.io/blog/paralus-cnfc-sandbox-project` to `https://www.paralus.io/blog/paralus-cncf-sandbox-project` (_cnfc to cncf_)
