### PR TITLE
Pin the SSO mapper urls to v0.2.2 tag

### DIFF
--- a/docs/Single Sign On/gitlab.md
+++ b/docs/Single Sign On/gitlab.md
@@ -38,7 +38,7 @@ Click Save & Continue.
 
 From the next screen copy the `Callback URL` and paste it in the callback URL for the GitLab OAuth app created in the earlier step.
 
-On the **Mapper Configuration** screen, provide `https://raw.githubusercontent.com/paralus/paralus/main/_kratos/oidc-mappers/gitlab.jsonnet` as the mapper url.
+On the **Mapper Configuration** screen, provide `https://raw.githubusercontent.com/paralus/paralus/v0.2.2/_kratos/oidc-mappers/gitlab.jsonnet` as the mapper url.
 
 Click Save & Exit.
 

--- a/docs/Single Sign On/okta.md
+++ b/docs/Single Sign On/okta.md
@@ -69,7 +69,7 @@ Click Save & Continue.
 
 From the next screen copy the `Callback URL` and paste it in the callback URL for the Okta OAuth app created in the earlier step.
 
-On the **Mapper Configuration** screen, provide `https://raw.githubusercontent.com/paralus/paralus/main/_kratos/oidc-mappers/okta.jsonnet` as the mapper url. The mapper url uses [the custom groups claim](#add-a-custom-groups-claim).
+On the **Mapper Configuration** screen, provide `https://raw.githubusercontent.com/paralus/paralus/v0.2.2/_kratos/oidc-mappers/okta.jsonnet` as the mapper url. The mapper url uses [the custom groups claim](#add-a-custom-groups-claim).
 
 Click Save & Exit.
 

--- a/docs/Single Sign On/slack.md
+++ b/docs/Single Sign On/slack.md
@@ -43,7 +43,7 @@ Click Save & Continue.
 
 From the next screen copy the `Callback URL` and paste it in the redirect URL for the Slack OAuth app created in the earlier step.
 
-On the **Mapper Configuration** screen, provide `https://raw.githubusercontent.com/paralus/paralus/main/_kratos/oidc-mappers/slack.jsonnet` as the mapper url. Click Save & Exit.
+On the **Mapper Configuration** screen, provide `https://raw.githubusercontent.com/paralus/paralus/v0.2.2/_kratos/oidc-mappers/slack.jsonnet` as the mapper url. Click Save & Exit.
 
 At this point, you have successfully added Slack as an identity provider for Paralus.
 


### PR DESCRIPTION
Mapper url from main branch is suppose to change. In case we change the mapper content then the user will start experience failures while logging in using SSO. Hence pinned mapper urls to fixed tag to prevent any failures.